### PR TITLE
Add chat functionality

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,6 +10,7 @@ import Favorites from "@/pages/favorites";
 import Search from "@/pages/search";
 import Profile from "@/pages/profile";
 import Quiz from "@/pages/quiz";
+import Chat from "@/pages/chat";
 import NotFound from "@/pages/not-found";
 
 function Router() {
@@ -21,6 +22,7 @@ function Router() {
       <Route path="/favorites" component={Favorites} />
       <Route path="/search" component={Search} />
       <Route path="/profile" component={Profile} />
+      <Route path="/chat" component={Chat} />
       <Route path="/quiz" component={Quiz} />
       <Route component={NotFound} />
     </Switch>

--- a/client/src/components/bottom-navigation.tsx
+++ b/client/src/components/bottom-navigation.tsx
@@ -8,6 +8,7 @@ export function BottomNavigation() {
     { path: "/", icon: "fas fa-home", label: "Start" },
     { path: "/search", icon: "fas fa-search", label: "Suchen" },
     { path: "/favorites", icon: "fas fa-heart", label: "Favoriten" },
+    { path: "/chat", icon: "fas fa-comments", label: "Chat" },
     { path: "/profile", icon: "fas fa-user", label: "Profil" },
   ];
 

--- a/client/src/pages/chat.tsx
+++ b/client/src/pages/chat.tsx
@@ -1,0 +1,85 @@
+import { useState, useRef } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Header } from "@/components/header";
+import { BottomNavigation } from "@/components/bottom-navigation";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+interface ChatMessage {
+  id: number;
+  userId: string;
+  message: string;
+  timestamp: string;
+  role: string;
+}
+
+export default function Chat() {
+  const userId = "demo";
+  const [text, setText] = useState("");
+  const queryClient = useQueryClient();
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  const { data: messages = [] } = useQuery<ChatMessage[]>({
+    queryKey: ["/api/chat", { userId }],
+    queryFn: async () => {
+      const res = await fetch(`/api/chat/${userId}`);
+      if (!res.ok) throw new Error("Failed to fetch messages");
+      return res.json();
+    },
+  });
+
+  const sendMutation = useMutation({
+    mutationFn: async () => {
+      const res = await fetch("/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId, message: text }),
+      });
+      if (!res.ok) throw new Error("Failed to send message");
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/chat", { userId }] });
+      setText("");
+      setTimeout(() => bottomRef.current?.scrollIntoView({ behavior: "smooth" }), 100);
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!text.trim()) return;
+    sendMutation.mutate();
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col pb-24 bg-white">
+      <Header onOpenParentalDashboard={() => {}} />
+      <main className="flex-1 overflow-y-auto p-4 space-y-4">
+        {messages.map((m) => (
+          <div
+            key={m.id}
+            className={`p-3 rounded-xl max-w-md ${m.role === "user" ? "bg-coral text-white self-end ml-auto" : "bg-gray-100"}`}
+          >
+            {m.message}
+          </div>
+        ))}
+        {sendMutation.isLoading && (
+          <div className="p-3 rounded-xl bg-gray-100 max-w-md">
+            <i className="fas fa-spinner fa-spin"></i>
+          </div>
+        )}
+        <div ref={bottomRef}></div>
+      </main>
+      <form onSubmit={handleSubmit} className="p-4 flex space-x-2 fixed bottom-0 left-0 right-0 bg-white border-t">
+        <Input
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="Nachricht senden..."
+          className="flex-1"
+        />
+        <Button type="submit" disabled={sendMutation.isLoading || !text.trim()}>Senden</Button>
+      </form>
+      <BottomNavigation />
+    </div>
+  );
+}

--- a/server/database-storage.ts
+++ b/server/database-storage.ts
@@ -1,4 +1,4 @@
-import { categories, videos, playlists, userProgress, userSettings, favorites, type Category, type Video, type Playlist, type UserProgress, type UserSettings, type Favorite, type InsertCategory, type InsertVideo, type InsertPlaylist, type InsertUserProgress, type InsertUserSettings, type InsertFavorite } from "@shared/schema";
+import { categories, videos, playlists, userProgress, userSettings, favorites, chatMessages, type Category, type Video, type Playlist, type UserProgress, type UserSettings, type Favorite, type ChatMessage, type InsertCategory, type InsertVideo, type InsertPlaylist, type InsertUserProgress, type InsertUserSettings, type InsertFavorite, type InsertChatMessage } from "@shared/schema";
 import { db } from "./db";
 import { eq, and, like, or } from "drizzle-orm";
 import type { IStorage } from "./storage";
@@ -183,5 +183,14 @@ export class DatabaseStorage implements IStorage {
   async isFavorite(videoId: number): Promise<boolean> {
     const [favorite] = await db.select().from(favorites).where(eq(favorites.videoId, videoId)).limit(1);
     return !!favorite;
+  }
+
+  async getChatMessages(userId: string): Promise<ChatMessage[]> {
+    return await db.select().from(chatMessages).where(eq(chatMessages.userId, userId)).orderBy(chatMessages.timestamp);
+  }
+
+  async addChatMessage(message: InsertChatMessage): Promise<ChatMessage> {
+    const [newMessage] = await db.insert(chatMessages).values(message).returning();
+    return newMessage;
   }
 }

--- a/server/llm.ts
+++ b/server/llm.ts
@@ -1,0 +1,26 @@
+export async function getChatCompletion(messages: {role: string; content: string;}[]): Promise<string> {
+  const apiKey = process.env.LLM_API_KEY || process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error("LLM_API_KEY not configured");
+  }
+
+  const res = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: "gpt-3.5-turbo",
+      messages,
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`LLM request failed: ${res.status} ${text}`);
+  }
+
+  const data = await res.json();
+  return data.choices?.[0]?.message?.content || "";
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3,6 +3,8 @@ import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import { youtubeIntegration } from "./youtube-integration";
 import { insertVideoSchema, insertPlaylistSchema, insertUserProgressSchema, insertUserSettingsSchema, insertFavoriteSchema } from "@shared/schema";
+import type { ChatMessage } from "@shared/schema";
+import { getChatCompletion } from "./llm";
 
 export async function registerRoutes(app: Express): Promise<Server> {
   // Categories
@@ -201,6 +203,47 @@ export async function registerRoutes(app: Express): Promise<Server> {
       res.json({ isFavorite });
     } catch (error) {
       res.status(500).json({ message: "Failed to check favorite status" });
+    }
+  });
+
+  // Chat
+  app.get("/api/chat/:userId", async (req, res) => {
+    try {
+      const messages = await storage.getChatMessages(req.params.userId);
+      res.json(messages);
+    } catch (error) {
+      res.status(500).json({ message: "Failed to fetch messages" });
+    }
+  });
+
+  app.post("/api/chat", async (req, res) => {
+    try {
+      const { userId, message } = req.body;
+      if (!userId || !message) {
+        return res.status(400).json({ message: "userId and message required" });
+      }
+      const userMsg = await storage.addChatMessage({
+        userId,
+        message,
+        timestamp: new Date().toISOString(),
+        role: "user",
+      });
+
+      const assistantText = await getChatCompletion([
+        { role: "user", content: message },
+      ]);
+
+      const assistantMsg = await storage.addChatMessage({
+        userId,
+        message: assistantText,
+        timestamp: new Date().toISOString(),
+        role: "assistant",
+      });
+
+      res.json([userMsg, assistantMsg]);
+    } catch (error) {
+      console.error("chat error", error);
+      res.status(500).json({ message: "Chat failed" });
     }
   });
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,9 +1,10 @@
-import { 
-  categories, videos, playlists, userProgress, userSettings, favorites,
-  type Category, type Video, type Playlist, type UserProgress, type UserSettings, type Favorite,
-  type InsertCategory, type InsertVideo, type InsertPlaylist, type InsertUserProgress, 
-  type InsertUserSettings, type InsertFavorite
+import {
+  categories, videos, playlists, userProgress, userSettings, favorites, chatMessages,
+  type Category, type Video, type Playlist, type UserProgress, type UserSettings, type Favorite, type ChatMessage,
+  type InsertCategory, type InsertVideo, type InsertPlaylist, type InsertUserProgress,
+  type InsertUserSettings, type InsertFavorite, type InsertChatMessage
 } from "@shared/schema";
+import { DatabaseStorage } from "./database-storage";
 
 export interface IStorage {
   // Categories
@@ -36,6 +37,10 @@ export interface IStorage {
   addFavorite(favorite: InsertFavorite): Promise<Favorite>;
   removeFavorite(videoId: number): Promise<boolean>;
   isFavorite(videoId: number): Promise<boolean>;
+
+  // Chat
+  getChatMessages(userId: string): Promise<ChatMessage[]>;
+  addChatMessage(message: InsertChatMessage): Promise<ChatMessage>;
 }
 
 export class MemStorage implements IStorage {
@@ -45,6 +50,7 @@ export class MemStorage implements IStorage {
   private userProgress: Map<number, UserProgress>;
   private userSettings: UserSettings;
   private favorites: Map<number, Favorite>;
+  private chatMessages: Map<number, ChatMessage>;
   private currentId: number;
 
   constructor() {
@@ -53,6 +59,7 @@ export class MemStorage implements IStorage {
     this.playlists = new Map();
     this.userProgress = new Map();
     this.favorites = new Map();
+    this.chatMessages = new Map();
     this.currentId = 1;
 
     // Initialize with default user settings
@@ -1025,7 +1032,17 @@ export class MemStorage implements IStorage {
   async isFavorite(videoId: number): Promise<boolean> {
     return Array.from(this.favorites.values()).some(f => f.videoId === videoId);
   }
+
+  async getChatMessages(userId: string): Promise<ChatMessage[]> {
+    return Array.from(this.chatMessages.values()).filter(m => m.userId === userId);
+  }
+
+  async addChatMessage(message: InsertChatMessage): Promise<ChatMessage> {
+    const id = this.currentId++;
+    const newMessage: ChatMessage = { id, ...message } as ChatMessage;
+    this.chatMessages.set(id, newMessage);
+    return newMessage;
+  }
 }
 
-// Use memory storage for now since database integration has issues
-export const storage = new MemStorage();
+export const storage = new DatabaseStorage();

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -62,6 +62,14 @@ export const favorites = pgTable("favorites", {
   addedAt: text("added_at").notNull(),
 });
 
+export const chatMessages = pgTable("chat_messages", {
+  id: serial("id").primaryKey(),
+  userId: text("user_id").notNull(),
+  message: text("message").notNull(),
+  timestamp: text("timestamp").notNull(),
+  role: text("role").notNull(),
+});
+
 // Insert schemas
 export const insertCategorySchema = createInsertSchema(categories).omit({ id: true });
 export const insertVideoSchema = createInsertSchema(videos).omit({ id: true });
@@ -69,6 +77,7 @@ export const insertPlaylistSchema = createInsertSchema(playlists).omit({ id: tru
 export const insertUserProgressSchema = createInsertSchema(userProgress).omit({ id: true });
 export const insertUserSettingsSchema = createInsertSchema(userSettings).omit({ id: true });
 export const insertFavoriteSchema = createInsertSchema(favorites).omit({ id: true });
+export const insertChatMessageSchema = createInsertSchema(chatMessages).omit({ id: true });
 
 // Types
 export type Category = typeof categories.$inferSelect;
@@ -77,6 +86,7 @@ export type Playlist = typeof playlists.$inferSelect;
 export type UserProgress = typeof userProgress.$inferSelect;
 export type UserSettings = typeof userSettings.$inferSelect;
 export type Favorite = typeof favorites.$inferSelect;
+export type ChatMessage = typeof chatMessages.$inferSelect;
 
 export type InsertCategory = z.infer<typeof insertCategorySchema>;
 export type InsertVideo = z.infer<typeof insertVideoSchema>;
@@ -84,3 +94,4 @@ export type InsertPlaylist = z.infer<typeof insertPlaylistSchema>;
 export type InsertUserProgress = z.infer<typeof insertUserProgressSchema>;
 export type InsertUserSettings = z.infer<typeof insertUserSettingsSchema>;
 export type InsertFavorite = z.infer<typeof insertFavoriteSchema>;
+export type InsertChatMessage = z.infer<typeof insertChatMessageSchema>;


### PR DESCRIPTION
## Summary
- store chat messages in a new `chat_messages` table
- use `DatabaseStorage` by default and add helpers for chat
- expose `/api/chat` REST endpoints
- implement OpenAI request helper
- add chat page and navigation link

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68365b9e62ec8320a87340f7b7e4d1d9